### PR TITLE
Feature/input type post

### DIFF
--- a/src/express.ts
+++ b/src/express.ts
@@ -1,5 +1,12 @@
 import * as express from 'express';
-import { DocumentNode, print, isObjectType, isNonNullType } from 'graphql';
+import {
+  DocumentNode,
+  print,
+  isObjectType,
+  isNonNullType,
+  GraphQLInputObjectType,
+  GraphQLNonNull,
+} from 'graphql';
 
 import { buildOperation } from './operation';
 import { getOperationInfo, OperationInfo } from './ast';
@@ -149,14 +156,16 @@ function createQueryRoute({
   const hasIdArgument = field.args.some(arg => arg.name === 'id');
   const path = getPath(fieldName, isSingle && hasIdArgument);
 
-  router.get(path, useHandler({ info, fieldName, sofa, operation }));
+  const method = field.args.find(arg => isInputType(arg.type)) ? 'post' : 'get';
+
+  router[method](path, useHandler({ info, fieldName, sofa, operation }));
 
   logger.debug(`[Router] ${fieldName} query available at ${path}`);
 
   return {
     document: operation,
     path,
-    method: 'GET',
+    method: method.toUpperCase() as 'POST' | 'GET',
   };
 }
 
@@ -257,6 +266,15 @@ function pickParam(req: express.Request, name: string) {
   if (req.body && req.body[name]) {
     return req.body[name];
   }
+}
+
+// Graphql provided isInputType accepts GraphQLScalarType, GraphQLEnumType.
+function isInputType(type: any): boolean {
+  if (type instanceof GraphQLNonNull) {
+    return isInputType(type.ofType);
+  }
+
+  return type instanceof GraphQLInputObjectType;
 }
 
 function useAsync<T = any>(

--- a/src/open-api/index.ts
+++ b/src/open-api/index.ts
@@ -55,6 +55,7 @@ export function OpenAPI({
         url: path,
         operation: info.document,
         schema,
+        useRequestBody: info.method === 'POST',
       });
     },
     get() {

--- a/src/open-api/operations.ts
+++ b/src/open-api/operations.ts
@@ -14,20 +14,21 @@ export function buildPathFromOperation({
   url,
   schema,
   operation,
+  useRequestBody,
 }: {
   url: string;
   schema: GraphQLSchema;
   operation: DocumentNode;
+  useRequestBody: boolean;
 }) {
   const info = getOperationInfo(operation)!;
-  const isQuery = info.operation.operation === 'query';
 
   return {
     operationId: info.name,
-    parameters: isQuery
+    parameters: !useRequestBody
       ? resolveParameters(url, info.operation.variableDefinitions)
       : [],
-    requestBody: !isQuery
+    requestBody: useRequestBody
       ? {
           content: {
             'application/json': {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -51,7 +51,7 @@ function resolveVariable({
     }
 
     if (isInputObjectType(namedType)) {
-      return value && JSON.parse(value);
+      return value && typeof value === 'object' ? value : JSON.parse(value);
     }
 
     return value;

--- a/tests/open-api/operations.spec.ts
+++ b/tests/open-api/operations.spec.ts
@@ -37,6 +37,7 @@ test('handle query', async () => {
     url: '/api/feed',
     operation,
     schema,
+    useRequestBody: false,
   });
 
   expect(result.operationId).toEqual('feedQuery');
@@ -70,6 +71,7 @@ test('handle mutation', async () => {
     url: '/api/add-post',
     operation,
     schema,
+    useRequestBody: true,
   });
 
   // id

--- a/tests/router.spec.ts
+++ b/tests/router.spec.ts
@@ -1,6 +1,7 @@
 import { makeExecutableSchema } from 'graphql-tools';
 import * as supertest from 'supertest';
 import * as express from 'express';
+import bodyParser = require('body-parser');
 import { schema, models } from './schema';
 import { createRouter } from '../src/express';
 import { createSofa } from '../src';
@@ -62,6 +63,7 @@ test('should parse InputTypeObject', done => {
       name: 'Foo',
     },
   ];
+  const spy = jest.fn(() => users);
   const sofa = createSofa({
     schema: makeExecutableSchema({
       typeDefs: /* GraphQL */ `
@@ -69,19 +71,19 @@ test('should parse InputTypeObject', done => {
           offset: Int
           limit: Int!
         }
-    
+
         type User {
           id: ID
           name: String
         }
-        
+
         type Query {
           users(pageInfo: PageInfoInput!): [User]
         }
       `,
       resolvers: {
         Query: {
-          users: () => users,
+          users: spy,
         },
       },
     }),
@@ -90,15 +92,24 @@ test('should parse InputTypeObject', done => {
   const router = createRouter(sofa);
   const app = express();
 
+  app.use(bodyParser.json());
   app.use('/api', router);
 
+  const params = {
+    pageInfo: {
+      limit: 5,
+    },
+  };
+
   supertest(app)
-    .get('/api/users?pageInfo={"limit": 5}')
+    .post('/api/users')
+    .send(params)
     .expect(200, (err, res) => {
       if (err) {
         done.fail(err);
       } else {
         expect(res.body).toEqual(users);
+        expect(spy.mock.calls[0][1]).toEqual(params);
         done();
       }
     });


### PR DESCRIPTION
If any of the query arguments are a graphql input type then a POST method will be registered for the given query. I think it is better to use POST than passing JSON in the http query params and then JSON.parse it.

I'm using prisma based graphql stack so my auto generated find one and find many queries accept input types instead of scalar args:
```graphql
type Query {
  user(where: UserWhereUniqueInput!): User
  users(after: String, before: String, first: Int, last: Int, orderBy: UserOrderByInput, skip: Int, where: UserWhereInput): [User!]!
}

input UserWhereUniqueInput {
  email: String
  id: ID
}

input UserWhereInput {
  AND: [UserWhereInput!]
  createdAt: DateTime
  createdAt_gt: DateTime
  #...
  updatedAt_not: DateTime
  updatedAt_not_in: [DateTime!]
}

```
Now I can call the API by:

```sh
curl -X POST "http://localhost:4000/api/user" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"where\":{\"id\":\"asd123\"}}"
```

instead of:
```sh
curl -X GET "http://localhost:4000/api/user?where={\"id\": \"asd123\"}" -H "accept: application/json"
```


