### PR TITLE
Show useSofa in docs instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ The best way to create REST APIs (is GraphQL).
 The most basic example possible:
 
 ```ts
-import sofa from 'sofa-api';
+import { useSofa } from 'sofa-api';
 import express from 'express';
 
 const app = express();
 
 app.use(
   '/api',
-  sofa({
+  useSofa({
     schema,
   })
 );
@@ -92,7 +92,7 @@ In order for Sofa to resolve operations based on a Context, you need te be able 
 ```ts
 api.use(
   '/api',
-  sofa({
+  useSofa({
     schema,
     async context({ req }) {
       return {
@@ -113,7 +113,7 @@ There are some cases where sending a full object makes more sense than passing o
 ```ts
 api.use(
   '/api',
-  sofa({
+  useSofa({
     schema,
     ignore: ['Message.author'],
   })
@@ -131,7 +131,7 @@ Sofa prevents circular references by default, but only one level deep. In order 
 ```ts
 api.use(
   '/api',
-  sofa({
+  useSofa({
     schema,
     depthLimit: 2,
   })
@@ -145,7 +145,7 @@ By default, Sofa uses `graphql` function from `graphql-js` to turn an operation 
 ```ts
 api.use(
   '/api',
-  sofa({
+  useSofa({
     schema,
     async execute(args) {
       return yourOwnLogicHere(args);
@@ -225,7 +225,7 @@ In return we get an `id` that we later on use to stop or update subscription:
 Thanks to GraphQL's Type System Sofa is able to generate OpenAPI (Swagger) definitions out of it. Possibilities are endless here. You get all the information you need in order to write your own definitions or create a plugin that follows any specification.
 
 ```ts
-import sofa, { OpenAPI } from 'sofa-api';
+import { useSofa, OpenAPI } from 'sofa-api';
 
 const openApi = OpenAPI({
   schema,
@@ -237,7 +237,7 @@ const openApi = OpenAPI({
 
 app.use(
   '/api',
-  sofa({
+  useSofa({
     schema,
     onRoute(info) {
       openApi.addRoute(info, {

--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -11,7 +11,7 @@ Sofa allows to build a context object through a factory function. You get an acc
 ```typescript
 api.use(
   '/api',
-  sofa({
+  useSofa({
     schema,
     async context({ req }) {
       return {
@@ -30,7 +30,7 @@ You can also pass any data, directly, without using a function.
 ```typescript
 api.use(
   '/api',
-  sofa({
+  useSofa({
     schema,
     context: yourContext,
   })

--- a/docs/api/execute.md
+++ b/docs/api/execute.md
@@ -7,7 +7,7 @@ By default, Sofa uses `graphql` function from `graphql-js` package to resolve an
 ```typescript
 api.use(
   '/api',
-  sofa({
+  useSofa({
     schema,
     async execute(args) {
       return yourOwnLogicHere(args);

--- a/docs/api/ignore.md
+++ b/docs/api/ignore.md
@@ -7,7 +7,7 @@ There are some cases where sending a full object makes more sense than passing o
 ```typescript
 api.use(
   '/api',
-  sofa({
+  useSofa({
     schema,
     ignore: ['Message.author'],
   })

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,12 +29,12 @@ npm install sofa-api
 ### Usage
 
 ```typescript
-import sofa from 'sofa-api';
+import { useSofa } from 'sofa-api';
 import express from 'express';
 
 const app = express();
 
-app.use('/api', sofa({ schema }));
+app.use('/api', useSofa({ schema }));
 
 // GET  /api/messages
 // POST /api/add-message

--- a/docs/recipes/open-api.md
+++ b/docs/recipes/open-api.md
@@ -5,7 +5,7 @@ title: OpenAPI (Swagger)
 Thanks to GraphQL's Type System Sofa is able to generate OpenAPI (Swagger) definitions out of it. Possibilities are endless here. You get all the information you need in order to write your own definitions or create a plugin that follows any specification.
 
 ```ts
-import sofa, { OpenAPI } from 'sofa-api';
+import { OpenAPI, useSofa } from 'sofa-api';
 
 const openApi = OpenAPI({
   schema,
@@ -17,7 +17,7 @@ const openApi = OpenAPI({
 
 app.use(
   '/api',
-  sofa({
+  useSofa({
     schema,
     onRoute(info) {
       openApi.addRoute(info, {

--- a/example/index.ts
+++ b/example/index.ts
@@ -20,7 +20,7 @@ app.use(bodyParser.json());
 
 const schema = makeExecutableSchema({
   typeDefs,
-  resolvers: resolvers as any,
+  resolvers,
 });
 
 const openApi = OpenAPI({

--- a/example/index.ts
+++ b/example/index.ts
@@ -11,7 +11,7 @@ import * as swaggerDocument from './swagger.json';
 
 // Sofa
 
-import sofa, { OpenAPI } from '../src';
+import { useSofa, OpenAPI } from '../src';
 import { logger } from '../src/logger';
 
 const app = express();
@@ -32,7 +32,7 @@ const openApi = OpenAPI({
 });
 
 app.use(
-  sofa({
+  useSofa({
     schema,
     ignore: ['User.favoriteBook'],
     onRoute(info) {

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
   "devDependencies": {
     "@types/body-parser": "1.17.0",
     "@types/express": "4.16.0",
-    "@types/express-graphql": "0.6.2",
-    "@types/graphql": "14.0.3",
+    "@types/express-graphql": "0.8.0",
+    "@types/graphql": "14.2.2",
     "@types/jest": "23.3.10",
     "@types/request-promise-native": "1.0.15",
     "@types/supertest": "2.0.7",


### PR DESCRIPTION
#38 Related
Some people might use CommonJS instead of `default` import of ES Modules syntax. So, it would be better to use `useSofa` in docs to prevent confusion.
