### PR TITLE
Add errorHandling option for custom error handling

### DIFF
--- a/docs/api/error-handler.md
+++ b/docs/api/error-handler.md
@@ -1,0 +1,19 @@
+---
+title: Error Handling
+---
+
+By default, Sofa returns a response that includes JSON representation of thrown error object from GraphQL with HTTP status code 500. But, you can enhance error handler by adding your `errorHandler` function.
+
+```typescript
+api.use(
+  '/api',
+  sofa({
+    schema,
+    errorHandler(res, error) {
+      logError(error);
+      res.code(500);
+      res.json(formatError(error));
+    },
+  })
+);
+```

--- a/example/resolvers.ts
+++ b/example/resolvers.ts
@@ -37,6 +37,9 @@ export const resolvers: any = {
     feed() {
       return PostsCollection.all();
     },
+    never() {
+      throw new Error('Some Message');
+    },
   },
   Mutation: {
     addBook(_: any, { title }: any) {

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
   "devDependencies": {
     "@types/body-parser": "1.17.0",
     "@types/express": "4.16.0",
-    "@types/express-graphql": "0.6.2",
-    "@types/graphql": "14.0.3",
+    "@types/express-graphql": "0.8.0",
+    "@types/graphql": "14.2.2",
     "@types/jest": "23.3.10",
     "@types/request-promise-native": "1.0.15",
     "@types/supertest": "2.0.7",
@@ -72,7 +72,7 @@
     "swagger-ui-express": "4.0.2",
     "ts-jest": "23.10.5",
     "ts-loader": "5.3.1",
-    "ts-node": "7.0.1",
+    "ts-node": "8.3.0",
     "typescript": "3.2.2",
     "webpack": "4.27.1",
     "webpack-cli": "3.1.2"

--- a/src/express.ts
+++ b/src/express.ts
@@ -234,7 +234,14 @@ function useHandler(config: {
 
     // TODO: add error handling for result.errors
     if (result.errors) {
-      throw new Error(result.errors.toString());
+      const defaultErrorHandler: ErrorHandler = (res, error) => {
+        res.status(500);
+        res.json(error);
+      };
+      const errorHandler: ErrorHandler =
+        sofa.errorHandler || defaultErrorHandler;
+      errorHandler(res, result.errors[0]);
+      return;
     }
 
     res.json(result.data && result.data[fieldName]);

--- a/src/sofa.ts
+++ b/src/sofa.ts
@@ -13,6 +13,7 @@ import {
 import { Ignore, Context, ContextFn, ExecuteFn, OnRoute } from './types';
 import { convertName } from './common';
 import { logger } from './logger';
+import { ErrorHandler } from './express';
 
 // user passes:
 // - schema
@@ -27,6 +28,7 @@ export interface SofaConfig {
   ignore?: Ignore; // treat an Object with an ID as not a model - accepts ['User', 'Message.author']
   onRoute?: OnRoute;
   depthLimit?: number;
+  errorHandler?: ErrorHandler;
 }
 
 export interface Sofa {
@@ -36,6 +38,7 @@ export interface Sofa {
   ignore: Ignore;
   execute: ExecuteFn;
   onRoute?: OnRoute;
+  errorHandler?: ErrorHandler;
 }
 
 export function createSofa(config: SofaConfig): Sofa {

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -7,6 +7,12 @@
       "essentials/subscriptions"
     ],
     "Recipes": ["recipes/open-api"],
-    "API": ["api/models", "api/context", "api/ignore", "api/execute"]
+    "API": [
+      "api/models",
+      "api/context",
+      "api/ignore",
+      "api/execute",
+      "api/error-handler"
+    ]
   }
 }


### PR DESCRIPTION
Related #44 

* Return `JSON` representation of `GraphQLError` by default with 500 status code.
* Add `errorHandler` option `SofaConfig` for custom error handling.
