### PR TITLE
fix: Fix typename in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Sofa takes your GraphQL Schema, looks for available queries, mutations and subsc
 Given the following schema:
 
 ```graphql
-type User {
+type Chat {
   id: ID
   name: String
 }


### PR DESCRIPTION
## Motivation

I'm not 100% sure but in documentation example defines User as type but use Chat in queries. Made quick fix for that