### PR TITLE
feat: add enum support to openapi

### DIFF
--- a/example/collections.ts
+++ b/example/collections.ts
@@ -2,7 +2,10 @@ const pizzas = [
   { id: 1, dough: 'pan', toppings: ['cheese'] },
   { id: 2, dough: 'classic', toppings: ['ham'] },
 ];
-const books = [{ id: 1, title: 'Book A' }, { id: 2, title: 'Book B' }];
+const books = [
+  { id: 1, title: 'Book A', type: 'AUDIO' },
+  { id: 2, title: 'Book B', type: 'LEGACY' },
+];
 const users = [
   {
     id: 1,
@@ -40,7 +43,7 @@ export const UsersCollection = {
   get(id: string | number) {
     const uid = typeof id === 'string' ? parseInt(id, 10) : id;
 
-    return users.find(u => u.id === uid);
+    return users.find((u) => u.id === uid);
   },
   all() {
     return users;
@@ -51,20 +54,16 @@ export const BooksCollection = {
   get(id: string | number) {
     const bid = typeof id === 'string' ? parseInt(id, 10) : id;
 
-    return books.find(u => u.id === bid);
+    return books.find((u) => u.id === bid);
   },
   all() {
     return books;
   },
   add(title: string) {
     const book = {
-      id: parseInt(
-        Math.random()
-          .toString(10)
-          .substr(2),
-        10
-      ),
+      id: parseInt(Math.random().toString(10).substr(2), 10),
       title,
+      type: 'LEGACY',
     };
 
     books.push(book);

--- a/example/swagger.json
+++ b/example/swagger.json
@@ -263,6 +263,94 @@
   },
   "components": {
     "schemas": {
+      "Pizza": {
+        "type": "object",
+        "required": ["dough"],
+        "properties": {
+          "dough": {
+            "type": "string"
+          },
+          "toppings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Salad": {
+        "type": "object",
+        "required": ["ingredients"],
+        "properties": {
+          "ingredients": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Book": {
+        "type": "object",
+        "required": ["id", "title", "type"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["AUDIO", "LEGACY"]
+          }
+        }
+      },
+      "User": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "favoritePizza",
+          "favoriteBook",
+          "favoriteFood",
+          "shelf"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "favoritePizza": {
+            "$ref": "#/components/schemas/Pizza"
+          },
+          "favoriteBook": {
+            "$ref": "#/components/schemas/Book"
+          },
+          "favoriteFood": {
+            "type": "object"
+          },
+          "shelf": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Book"
+            }
+          }
+        }
+      },
+      "Post": {
+        "type": "object",
+        "properties": {
+          "comments": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "Query": {
         "type": "object",
         "properties": {
@@ -307,90 +395,6 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Post"
-            }
-          }
-        }
-      },
-      "User": {
-        "type": "object",
-        "required": [
-          "id",
-          "name",
-          "favoritePizza",
-          "favoriteBook",
-          "favoriteFood",
-          "shelf"
-        ],
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "favoritePizza": {
-            "$ref": "#/components/schemas/Pizza"
-          },
-          "favoriteBook": {
-            "$ref": "#/components/schemas/Book"
-          },
-          "favoriteFood": {
-            "type": "object"
-          },
-          "shelf": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Book"
-            }
-          }
-        }
-      },
-      "Pizza": {
-        "type": "object",
-        "required": ["dough"],
-        "properties": {
-          "dough": {
-            "type": "string"
-          },
-          "toppings": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "Book": {
-        "type": "object",
-        "required": ["id", "title"],
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      },
-      "Salad": {
-        "type": "object",
-        "required": ["ingredients"],
-        "properties": {
-          "ingredients": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "Post": {
-        "type": "object",
-        "properties": {
-          "comments": {
-            "type": "array",
-            "items": {
-              "type": "string"
             }
           }
         }

--- a/example/swagger.yml
+++ b/example/swagger.yml
@@ -165,6 +165,73 @@ paths:
                                 $ref: '#/components/schemas/Book'
 components:
     schemas:
+        Pizza:
+            type: object
+            required:
+                - dough
+            properties:
+                dough:
+                    type: string
+                toppings:
+                    type: array
+                    items:
+                        type: string
+        Salad:
+            type: object
+            required:
+                - ingredients
+            properties:
+                ingredients:
+                    type: array
+                    items:
+                        type: string
+        Book:
+            type: object
+            required:
+                - id
+                - title
+                - type
+            properties:
+                id:
+                    type: string
+                title:
+                    type: string
+                type:
+                    type: string
+                    enum:
+                        - AUDIO
+                        - LEGACY
+        User:
+            type: object
+            required:
+                - id
+                - name
+                - favoritePizza
+                - favoriteBook
+                - favoriteFood
+                - shelf
+            properties:
+                id:
+                    type: string
+                name:
+                    type: string
+                favoritePizza:
+                    $ref: '#/components/schemas/Pizza'
+                favoriteBook:
+                    $ref: '#/components/schemas/Book'
+                favoriteFood:
+                    type: object
+                shelf:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Book'
+        Post:
+            type: object
+            properties:
+                comments:
+                    type: array
+                    items:
+                        type: string
         Query:
             type: object
             properties:
@@ -197,67 +264,6 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/Post'
-        User:
-            type: object
-            required:
-                - id
-                - name
-                - favoritePizza
-                - favoriteBook
-                - favoriteFood
-                - shelf
-            properties:
-                id:
-                    type: string
-                name:
-                    type: string
-                favoritePizza:
-                    $ref: '#/components/schemas/Pizza'
-                favoriteBook:
-                    $ref: '#/components/schemas/Book'
-                favoriteFood:
-                    type: object
-                shelf:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/Book'
-        Pizza:
-            type: object
-            required:
-                - dough
-            properties:
-                dough:
-                    type: string
-                toppings:
-                    type: array
-                    items:
-                        type: string
-        Book:
-            type: object
-            required:
-                - id
-                - title
-            properties:
-                id:
-                    type: string
-                title:
-                    type: string
-        Salad:
-            type: object
-            required:
-                - ingredients
-            properties:
-                ingredients:
-                    type: array
-                    items:
-                        type: string
-        Post:
-            type: object
-            properties:
-                comments:
-                    type: array
-                    items:
-                        type: string
         Mutation:
             type: object
             properties:

--- a/example/types.ts
+++ b/example/types.ts
@@ -13,6 +13,12 @@ export const typeDefs = /* GraphQL */ `
   type Book {
     id: ID!
     title: String!
+    type: BookType!
+  }
+
+  enum BookType {
+    AUDIO
+    LEGACY
   }
 
   type User {

--- a/src/open-api/types.ts
+++ b/src/open-api/types.ts
@@ -9,6 +9,7 @@ import {
   isObjectType,
   isScalarType,
   GraphQLNamedType,
+  isEnumType,
 } from 'graphql';
 import { mapToPrimitive, mapToRef } from './utils';
 
@@ -74,6 +75,13 @@ export function resolveFieldType(
         type: 'object',
       }
     );
+  }
+
+  if (isEnumType(type)) {
+    return {
+      type: 'string',
+      enum: type.astNode?.values?.map((value) => value.name.value),
+    };
   }
 
   return {

--- a/tests/open-api/types.spec.ts
+++ b/tests/open-api/types.spec.ts
@@ -24,7 +24,13 @@ test('handle ObjectType', async () => {
       address: [Address]
     }
 
+    enum UserRole {
+      ADMIN
+      NORMAL
+    }
+
     type User {
+      role: UserRole!
       name: String!
       age: Int!
       profile: Profile
@@ -49,8 +55,12 @@ test('handle ObjectType', async () => {
 
   expect(user).toEqual({
     type: 'object',
-    required: ['name', 'age'],
+    required: ['role', 'name', 'age'],
     properties: {
+      role: {
+        enum: ['ADMIN', 'NORMAL'],
+        type: 'string',
+      },
       name: {
         type: 'string',
       },


### PR DESCRIPTION
Adds support to openapi [enums as defined in spec](https://swagger.io/docs/specification/data-models/enums/?sbsearch=enums). Enums are mentioned as missing feature in https://github.com/Urigo/SOFA/issues/186#issuecomment-573378623 also.


Note: Pre-commit hooks autoformat code for some lines I did not intend to change but I let them be.

### Example

Schema
```graphql
type Book {
  id: ID!
  title: String!
  type: BookType!
}

enum BookType {
  AUDIO
  LEGACY
}
```

Generated Swagger yaml
```yaml

Book:
    type: object
    required:
        - id
        - title
        - type
    properties:
        id:
            type: string
        title:
            type: string
        type:
            type: string
            enum:
                - AUDIO
                - LEGACY
```