### PR TITLE
Switch yaml.js to js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,14 +34,15 @@
   },
   "dependencies": {
     "@graphql-tools/utils": "6.0.8",
+    "@types/js-yaml": "3.12.4",
     "axios": "0.19.2",
-    "param-case": "3.0.3",
     "iterall": "1.3.0",
+    "js-yaml": "3.14.0",
+    "param-case": "3.0.3",
     "title-case": "3.0.2",
     "tslib": "2.0.0",
     "uuid": "8.1.0",
-    "winston": "3.2.1",
-    "yamljs": "0.3.0"
+    "winston": "3.2.1"
   },
   "scripts": {
     "start": "ts-node --project tsconfig.example.json example/index.ts",
@@ -54,6 +55,7 @@
     "ci:release:canary": "node bump.js && bob-update-version && npm publish dist --tag alpha --access public"
   },
   "devDependencies": {
+    "@graphql-tools/schema": "6.0.8",
     "@types/body-parser": "1.19.0",
     "@types/express": "4.17.6",
     "@types/jest": "25.2.3",
@@ -70,7 +72,6 @@
     "express": "4.17.1",
     "express-graphql": "0.9.0",
     "graphql": "15.1.0",
-    "@graphql-tools/schema": "6.0.8",
     "graphql-subscriptions": "1.1.0",
     "husky": "4.2.5",
     "jest": "26.0.1",

--- a/src/open-api/index.ts
+++ b/src/open-api/index.ts
@@ -4,7 +4,7 @@ import {
   isInputObjectType,
   isIntrospectionType,
 } from 'graphql';
-import { stringify as YAMLstringify } from 'yamljs';
+import { safeDump as YAMLstringify } from 'js-yaml';
 import { writeFileSync } from 'fs';
 
 import { buildSchemaObjectFromType } from './types';
@@ -64,7 +64,7 @@ export function OpenAPI({
         basePath +
         info.path.replace(
           /\:[a-z0-9]+\w/i,
-          param => `{${param.replace(':', '')}}`
+          (param) => `{${param.replace(':', '')}}`
         );
 
       if (!swagger.paths[path]) {
@@ -88,7 +88,7 @@ export function OpenAPI({
       if (isJSON.test(filepath)) {
         writeOutput(filepath, JSON.stringify(swagger, null, 2));
       } else if (isYAML.test(filepath)) {
-        writeOutput(filepath, YAMLstringify(swagger, Infinity));
+        writeOutput(filepath, YAMLstringify(swagger));
       } else {
         throw new Error('We only support JSON and YAML files');
       }


### PR DESCRIPTION
From yaml.js repo

> ⚠️ Development of this library has slowed-down

> I am still using yaml.js in production for some projects, it works fine in all the situations I needed it. That said, I am not actively working with raw javascript environments (mostly using haxe now, if you are curious), thus I don't have much bandwidth to actively provide support to the posted issues asking for new features or bugfixes that don't affect my own use cases of the library. If this situation is an issue for you, I suggest you use js-yaml which is a great and pretty feature-complete yaml parser and dumper for javascript. Pull Requests are still welcome, as long as they don't break the current set of unit tests!

> Thanks 🙏

Block style (Infinity in usage) is default in js-yaml.