### PR TITLE
Replace winston with custom logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,14 +35,14 @@
   "dependencies": {
     "@graphql-tools/utils": "6.1.0",
     "@types/js-yaml": "3.12.5",
+    "ansi-colors": "4.1.1",
     "axios": "0.20.0",
     "iterall": "1.3.0",
     "js-yaml": "3.14.0",
     "param-case": "3.0.3",
     "title-case": "3.0.2",
     "tslib": "2.0.1",
-    "uuid": "8.3.0",
-    "winston": "3.3.3"
+    "uuid": "8.3.0"
   },
   "scripts": {
     "start": "ts-node --project tsconfig.example.json example/index.ts",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,9 +2,14 @@ import * as colors from 'ansi-colors';
 
 type Level = 'error' | 'warn' | 'info' | 'debug';
 
-const currentLevel: Level = 'info';
-
 const levels: Level[] = ['error', 'warn', 'info', 'debug'];
+
+const toLevel = (string: void | string) =>
+  levels.includes(string as Level) ? (string as Level) : null;
+
+const currentLevel: Level = process.env.SOFA_DEBUG
+  ? 'debug'
+  : toLevel(process.env.SOFA_LOGGER_LEVEL) ?? 'info';
 
 const log = (level: Level, color: any, args: any[]) => {
   if (levels.indexOf(level) <= levels.indexOf(currentLevel)) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,28 @@
-import { createLogger, transports, format } from 'winston';
+import * as colors from 'ansi-colors';
 
-export const logger = createLogger({
-  transports: [new transports.Console()],
-  format: format.combine(format.colorize(), format.simple()),
-});
+type Level = 'error' | 'warn' | 'info' | 'debug';
+
+const currentLevel: Level = 'info';
+
+const levels: Level[] = ['error', 'warn', 'info', 'debug'];
+
+const log = (level: Level, color: any, args: any[]) => {
+  if (levels.indexOf(level) <= levels.indexOf(currentLevel)) {
+    console.log(`${color(level)}:`, ...args);
+  }
+};
+
+export const logger = {
+  error: (...args: any[]) => {
+    log('error', colors.red, args);
+  },
+  warn: (...args: any[]) => {
+    log('warn', colors.yellow, args);
+  },
+  info: (...args: any[]) => {
+    log('info', colors.green, args);
+  },
+  debug: (...args: any[]) => {
+    log('debug', colors.blue, args);
+  },
+};


### PR DESCRIPTION
Ref https://packagephobia.com/result?p=winston

I just found winston package is quote big for such simple task as
colorized logging. At least in this project all winston power was not used.

In this diff I added very basic loggin solution with for levels "error",
"warn", "info" and "debug".