### PR TITLE
Replace express with trouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ const app = express();
 app.use(
   '/api',
   useSofa({
+    basePath: '/api',
     schema,
   })
 );
@@ -94,6 +95,7 @@ In order for Sofa to resolve operations based on a Context, you need te be able 
 api.use(
   '/api',
   useSofa({
+    basePath: '/api',
     schema,
     async context({ req }) {
       return {
@@ -115,6 +117,7 @@ There are some cases where sending a full object makes more sense than passing o
 api.use(
   '/api',
   useSofa({
+    basePath: '/api',
     schema,
     ignore: ['Message.author'],
   })
@@ -153,6 +156,7 @@ Sofa prevents circular references by default, but only one level deep. In order 
 api.use(
   '/api',
   useSofa({
+    basePath: '/api',
     schema,
     depthLimit: 2,
   })
@@ -167,6 +171,7 @@ By default, Sofa uses `graphql` function from `graphql-js` to turn an operation 
 api.use(
   '/api',
   useSofa({
+    basePath: '/api',
     schema,
     async execute(args) {
       return yourOwnLogicHere(args);
@@ -259,6 +264,7 @@ const openApi = OpenAPI({
 app.use(
   '/api',
   useSofa({
+    basePath: '/api',
     schema,
     onRoute(info) {
       openApi.addRoute(info, {
@@ -302,6 +308,7 @@ const openApi = OpenAPI({
 app.use(
   '/api',
   useSofa({
+    basePath: '/api',
     schema,
     onRoute(info) {
       openApi.addRoute(info, {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "url": "https://github.com/Urigo"
   },
   "peerDependencies": {
-    "express": "^4.0.0",
     "graphql": "^0.13.2 || ^14.0.0 || ^15.0.0"
   },
   "dependencies": {
@@ -41,6 +40,7 @@
     "js-yaml": "4.0.0",
     "param-case": "3.0.4",
     "title-case": "3.0.3",
+    "trouter": "3.1.0",
     "tslib": "2.1.0",
     "uuid": "8.3.2"
   },
@@ -63,6 +63,7 @@
     "@types/request-promise-native": "1.0.17",
     "@types/supertest": "2.0.10",
     "@types/swagger-ui-express": "4.1.2",
+    "@types/trouter": "3.1.0",
     "@types/uuid": "8.3.0",
     "@types/yamljs": "0.2.31",
     "bob-the-bundler": "1.1.0",

--- a/src/express.ts
+++ b/src/express.ts
@@ -149,9 +149,11 @@ export function createRouter(sofa: Sofa): Middleware {
 
   return async (req, res, next) => {
     const url = req.originalUrl ?? req.url;
-    const slicedUrl = url.startsWith(sofa.basePath)
-      ? url.slice(sofa.basePath.length)
-      : url;
+    if (!url.startsWith(sofa.basePath)) {
+      next();
+      return;
+    }
+    const slicedUrl = url.slice(sofa.basePath.length);
     const obj = router.find(req.method, slicedUrl);
     try {
       for (const handler of obj.handlers) {

--- a/src/express.ts
+++ b/src/express.ts
@@ -159,6 +159,9 @@ export function createRouter(sofa: Sofa): Middleware {
       for (const handler of obj.handlers) {
         await handler(req, res, obj.params);
       }
+      if (!res.headersSent) {
+        next();
+      }
     } catch (error) {
       next(error);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
-import { Router } from 'express';
-
+import type { Middleware } from './express';
 import { createRouter } from './express';
 import { SofaConfig, createSofa } from './sofa';
 
 export { OpenAPI } from './open-api';
 
-function useSofa(config: SofaConfig): Router {
+function useSofa(config: SofaConfig): Middleware {
   return createRouter(createSofa(config));
 }
 

--- a/src/sofa.ts
+++ b/src/sofa.ts
@@ -29,6 +29,7 @@ import { ErrorHandler } from './express';
 // - context
 
 export interface SofaConfig {
+  basePath: string;
   schema: GraphQLSchema;
   context?: Context;
   execute?: ExecuteFn;
@@ -48,6 +49,7 @@ export interface SofaConfig {
 }
 
 export interface Sofa {
+  basePath: string;
   schema: GraphQLSchema;
   context: Context;
   models: string[];

--- a/tests/repro.spec.ts
+++ b/tests/repro.spec.ts
@@ -115,5 +115,5 @@ test('memory issue', async () => {
     })
   );
 
-  useSofa({ schema });
+  useSofa({ basePath: '/api', schema });
 });


### PR DESCRIPTION
After [recent change](https://github.com/Urigo/SOFA/pull/643) express is used only as router.

Alternatively to https://github.com/Urigo/SOFA/pull/644 in this diff I'm
trying to provide less invasive replacement. Trouter is microlibrary which
is able to parse url params and provides the same set of routing methods
as express.

Note: review with hidden whitespaces