### PR TITLE
Decouple sofa context from subscription manager

### DIFF
--- a/src/subscriptions.ts
+++ b/src/subscriptions.ts
@@ -65,7 +65,7 @@ export class SubscriptionManager {
   private operations = new Map<SubscriptionFieldName, BuiltOperation>();
   private clients = new Map<ID, StoredClient>();
 
-  constructor(private sofa: Sofa, private context: ContextValue) {
+  constructor(private sofa: Sofa, private contextValue: ContextValue) {
     this.buildOperations();
   }
 
@@ -173,7 +173,7 @@ export class SubscriptionManager {
       document,
       operationName,
       variableValues,
-      contextValue: this.context,
+      contextValue: this.contextValue,
     });
 
     if (isAsyncIterable(execution)) {


### PR DESCRIPTION
Currently sofa context is either record or function which depends on req
and res objects. Though since we are moving towards server-agnostic api
better reduce req/res passing across library.

In this diff I moved SubscriptionManager initialisation into common route.
And passed contextValue separately from sofa.

Note: review with hidden whitespaces.