### PR TITLE
Fix subscriptions and drop iterall

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@types/js-yaml": "4.0.0",
     "ansi-colors": "4.1.1",
     "axios": "0.21.1",
-    "iterall": "1.3.0",
     "js-yaml": "4.0.0",
     "param-case": "3.0.4",
     "title-case": "3.0.3",

--- a/tests/subscriptions.spec.ts
+++ b/tests/subscriptions.spec.ts
@@ -1,0 +1,118 @@
+jest.mock('axios', () => ({
+  default: {
+    post: jest.fn(),
+  },
+}));
+
+import axios from 'axios';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { PubSub } from 'graphql-subscriptions';
+import * as supertest from 'supertest';
+import * as express from 'express';
+import * as bodyParser from 'body-parser';
+import { createRouter } from '../src/express';
+import { createSofa } from '../src';
+
+const delay = (ms: number) => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+};
+
+const testBook1 = {
+  id: 'book-id-1',
+  title: 'Test Book 1',
+};
+const testBook2 = {
+  id: 'book-id-2',
+  title: 'Test Book 2',
+};
+const BOOK_ADDED = 'BOOK_ADDED';
+const typeDefs = /* GraphQL */ `
+  type Book {
+    id: ID!
+    title: String!
+  }
+  type Subscription {
+    onBook: Book!
+  }
+  type Query {
+    books: [Book!]
+  }
+`;
+
+test('should start subscriptions', async () => {
+  (axios.post as jest.Mock).mockClear();
+  const pubsub = new PubSub();
+  const sofa = createSofa({
+    basePath: '/api',
+    schema: makeExecutableSchema({
+      typeDefs,
+      resolvers: {
+        Subscription: {
+          onBook: {
+            subscribe: () => pubsub.asyncIterator([BOOK_ADDED]),
+          },
+        },
+      },
+    }),
+  });
+  const router = createRouter(sofa);
+
+  const app = express();
+  app.use(bodyParser.json());
+  app.use('/api', router);
+
+  const res = await supertest(app)
+    .post('/api/webhook')
+    .send({ subscription: 'onBook', url: '/book' })
+    .expect(200);
+  expect(res.body).toEqual({ id: expect.any(String) });
+  pubsub.publish(BOOK_ADDED, { onBook: testBook1 });
+  await delay(1000);
+  expect(axios.post).toBeCalledTimes(1);
+  expect(axios.post).toBeCalledWith('/book', {
+    data: { onBook: { id: 'book-id-1', title: 'Test Book 1' } },
+  });
+  pubsub.publish(BOOK_ADDED, { onBook: testBook2 });
+  await delay(1000);
+  expect(axios.post).toBeCalledTimes(2);
+  expect(axios.post).toBeCalledWith('/book', {
+    data: { onBook: { id: 'book-id-2', title: 'Test Book 2' } },
+  });
+});
+
+test('should stop subscriptions', async () => {
+  (axios.post as jest.Mock).mockClear();
+  const pubsub = new PubSub();
+  const sofa = createSofa({
+    basePath: '/api',
+    schema: makeExecutableSchema({
+      typeDefs,
+      resolvers: {
+        Subscription: {
+          onBook: {
+            subscribe: () => pubsub.asyncIterator([BOOK_ADDED]),
+          },
+        },
+      },
+    }),
+  });
+  const router = createRouter(sofa);
+
+  const app = express();
+  app.use(bodyParser.json());
+  app.use('/api', router);
+
+  const res = await supertest(app)
+    .post('/api/webhook')
+    .send({ subscription: 'onBook', url: '/book' })
+    .expect(200);
+  pubsub.publish(BOOK_ADDED, { onBook: testBook1 });
+  await delay(1000);
+  expect(axios.post).toBeCalledTimes(1);
+  await supertest(app).delete(`/api/webhook/${res.body.id}`).expect(200);
+  pubsub.publish(BOOK_ADDED, { onBook: testBook2 });
+  await delay(1000);
+  expect(axios.post).toBeCalledTimes(1);
+});


### PR DESCRIPTION
Async iterators/generators are supported since node 10.3
See here https://node.green/#ES2018-features-Asynchronous-Iterators-for-await-of-loops
We can drop now iterall.

To not break anything covered subscriptions with tests.
And found "stop" does not work because invoked twice and
fails the second time caz does not find item in this.clients map.