### PR TITLE
Decouple middleware from router

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,60 @@
-import type { Middleware } from './express';
+import * as http from 'http';
 import { createRouter } from './express';
-import { SofaConfig, createSofa } from './sofa';
+import { SofaConfig, createSofa, isContextFn } from './sofa';
 
 export { OpenAPI } from './open-api';
 
+type Request = http.IncomingMessage & {
+  method: string;
+  url: string;
+  originalUrl?: string;
+  body?: any;
+};
+
+type NextFunction = (err?: any) => void;
+
+type Middleware = (
+  req: Request,
+  res: http.ServerResponse,
+  next: NextFunction
+) => unknown;
+
 function useSofa(config: SofaConfig): Middleware {
-  return createRouter(createSofa(config));
+  const sofa = createSofa(config);
+  const route = createRouter(sofa);
+  return async (req, res, next) => {
+    try {
+      const contextValue = isContextFn(sofa.context)
+        ? await sofa.context({ req, res })
+        : sofa.context;
+      const response = await route({
+        method: req.method,
+        url: req.originalUrl ?? req.url,
+        body: req.body,
+        contextValue,
+      });
+      if (response == null) {
+        next();
+      } else {
+        const headers = {
+          'Content-Type': 'application/json',
+        };
+        if (response.statusMessage) {
+          res.writeHead(response.status, response.statusMessage, headers);
+        } else {
+          res.writeHead(response.status, headers);
+        }
+        if (response.type === 'result') {
+          res.end(JSON.stringify(response.body));
+        }
+        if (response.type === 'error') {
+          res.end(JSON.stringify(response.error));
+        }
+      }
+    } catch (error) {
+      next(error);
+    }
+  };
 }
 
 export { useSofa, createSofa };

--- a/tests/router.spec.ts
+++ b/tests/router.spec.ts
@@ -2,8 +2,7 @@ import { makeExecutableSchema } from '@graphql-tools/schema';
 import * as supertest from 'supertest';
 import * as express from 'express';
 import * as bodyParser from 'body-parser';
-import { createRouter } from '../src/express';
-import useSofa, { createSofa } from '../src';
+import { useSofa } from '../src';
 
 test('should work with Query and variables', async (done) => {
   const testUser = {
@@ -11,7 +10,7 @@ test('should work with Query and variables', async (done) => {
     name: 'Test User',
   };
   const spy = jest.fn(() => testUser);
-  const sofa = createSofa({
+  const sofa = useSofa({
     basePath: '/api',
     schema: makeExecutableSchema({
       typeDefs: /* GraphQL */ `
@@ -31,11 +30,9 @@ test('should work with Query and variables', async (done) => {
     }),
   });
 
-  const router = createRouter(sofa);
   const app = express();
-
   app.use(bodyParser.json());
-  app.use('/api', router);
+  app.use('/api', sofa);
 
   supertest(app)
     .get('/api/user/test-id')
@@ -53,7 +50,7 @@ test('should work with Query and variables', async (done) => {
 test('should work with Mutation', async (done) => {
   const pizza = { dough: 'dough', toppings: ['topping'] };
   const spy = jest.fn(() => ({ __typename: 'Pizza', ...pizza }));
-  const sofa = createSofa({
+  const sofa = useSofa({
     basePath: '/api',
     schema: makeExecutableSchema({
       typeDefs: /* GraphQL */ `
@@ -80,11 +77,9 @@ test('should work with Mutation', async (done) => {
     }),
   });
 
-  const router = createRouter(sofa);
   const app = express();
-
   app.use(bodyParser.json());
-  app.use('/api', router);
+  app.use('/api', sofa);
 
   supertest(app)
     .post('/api/add-random-food')
@@ -110,7 +105,7 @@ test('should overwrite a default http method on demand', (done) => {
   const spy = jest.fn(() => users);
   const spyMutation = jest.fn(() => users[0]);
 
-  const sofa = createSofa({
+  const sofa = useSofa({
     basePath: '/api',
     schema: makeExecutableSchema({
       typeDefs: /* GraphQL */ `
@@ -147,11 +142,9 @@ test('should overwrite a default http method on demand', (done) => {
     },
   });
 
-  const router = createRouter(sofa);
   const app = express();
-
   app.use(bodyParser.json());
-  app.use('/api', router);
+  app.use('/api', sofa);
 
   const params = {
     pageInfo: {

--- a/tests/subscriptions.spec.ts
+++ b/tests/subscriptions.spec.ts
@@ -10,8 +10,7 @@ import { PubSub } from 'graphql-subscriptions';
 import * as supertest from 'supertest';
 import * as express from 'express';
 import * as bodyParser from 'body-parser';
-import { createRouter } from '../src/express';
-import { createSofa } from '../src';
+import { useSofa } from '../src';
 
 const delay = (ms: number) => {
   return new Promise((resolve) => {
@@ -44,7 +43,7 @@ const typeDefs = /* GraphQL */ `
 test('should start subscriptions', async () => {
   (axios.post as jest.Mock).mockClear();
   const pubsub = new PubSub();
-  const sofa = createSofa({
+  const sofa = useSofa({
     basePath: '/api',
     schema: makeExecutableSchema({
       typeDefs,
@@ -57,11 +56,10 @@ test('should start subscriptions', async () => {
       },
     }),
   });
-  const router = createRouter(sofa);
 
   const app = express();
   app.use(bodyParser.json());
-  app.use('/api', router);
+  app.use('/api', sofa);
 
   const res = await supertest(app)
     .post('/api/webhook')
@@ -85,7 +83,7 @@ test('should start subscriptions', async () => {
 test('should stop subscriptions', async () => {
   (axios.post as jest.Mock).mockClear();
   const pubsub = new PubSub();
-  const sofa = createSofa({
+  const sofa = useSofa({
     basePath: '/api',
     schema: makeExecutableSchema({
       typeDefs,
@@ -98,11 +96,10 @@ test('should stop subscriptions', async () => {
       },
     }),
   });
-  const router = createRouter(sofa);
 
   const app = express();
   app.use(bodyParser.json());
-  app.use('/api', router);
+  app.use('/api', sofa);
 
   const res = await supertest(app)
     .post('/api/webhook')


### PR DESCRIPTION
Moved express-like middleware related code into useSofa.
createRouter now does not depends on specific server.

Will expose new api in separate PR.