### PR TITLE
Expose sofa router as public api

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,57 @@ The best way to create REST APIs (is GraphQL).
 
 ## Getting Started
 
-The most basic example possible:
+Here's complete example with no dependency on frameworks, but also integratable with any of them:
 
-```ts
+```js
+import http from 'http';
+import getStream from 'get-stream';
+import { createSofaRouter } from 'sofa-api';
+
+const invokeSofa = createSofaRouter({
+  basePath: '/api',
+  schema,
+});
+
+const server = http.createServer(async (req, res) => {
+  try {
+    consr response = await invokeSofa({
+      method: req.method,
+      url: req.url,
+      body: JSON.parse(await getStream(req)),
+      contextValue: {
+        req
+      },
+    });
+    if (response) {
+      const headers = {
+        'Content-Type': 'application/json',
+      };
+      if (response.statusMessage) {
+        res.writeHead(response.status, response.statusMessage, headers);
+      } else {
+        res.writeHead(response.status, headers);
+      }
+      if (response.type === 'result') {
+        res.end(JSON.stringify(response.body));
+      }
+      if (response.type === 'error') {
+        res.end(JSON.stringify(response.error));
+      }
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  } catch (error) {
+    res.writeHead(500);
+    res.end(JSON.stringify(error));
+  }
+});
+```
+
+Another example with builtin express-like frameworks support
+
+```js
 import { useSofa } from 'sofa-api';
 import express from 'express';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export function useSofa({
   context,
   ...config
 }: SofaMiddlewareConfig): Middleware {
-  const route = createSofaRouter(config);
+  const invokeSofa = createSofaRouter(config);
   return async (req, res, next) => {
     try {
       let contextValue: ContextValue = { req };
@@ -46,7 +46,7 @@ export function useSofa({
           contextValue = context;
         }
       }
-      const response = await route({
+      const response = await invokeSofa({
         method: req.method,
         url: req.originalUrl ?? req.url,
         body: req.body,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import * as http from 'http';
 import { createRouter } from './express';
-import { SofaConfig, createSofa, isContextFn } from './sofa';
+import type { ContextValue } from './types';
+import type { SofaConfig } from './sofa';
+import { createSofa } from './sofa';
 
 export { OpenAPI } from './open-api';
 
@@ -19,14 +21,31 @@ type Middleware = (
   next: NextFunction
 ) => unknown;
 
-function useSofa(config: SofaConfig): Middleware {
-  const sofa = createSofa(config);
-  const route = createRouter(sofa);
+export type ContextFn = (init: { req: any; res: any }) => ContextValue;
+
+export function isContextFn(context: any): context is ContextFn {
+  return typeof context === 'function';
+}
+
+interface SofaMiddlewareConfig extends SofaConfig {
+  context?: ContextValue | ContextFn;
+}
+
+export function useSofa({
+  context,
+  ...config
+}: SofaMiddlewareConfig): Middleware {
+  const route = createSofaRouter(config);
   return async (req, res, next) => {
     try {
-      const contextValue = isContextFn(sofa.context)
-        ? await sofa.context({ req, res })
-        : sofa.context;
+      let contextValue: ContextValue = { req };
+      if (context) {
+        if (typeof context === 'function') {
+          contextValue = await context({ req, res });
+        } else {
+          contextValue = context;
+        }
+      }
       const response = await route({
         method: req.method,
         url: req.originalUrl ?? req.url,
@@ -57,5 +76,8 @@ function useSofa(config: SofaConfig): Middleware {
   };
 }
 
-export { useSofa, createSofa };
-export default useSofa;
+export function createSofaRouter(config: SofaConfig) {
+  const sofa = createSofa(config);
+  const router = createRouter(sofa);
+  return router;
+}

--- a/src/sofa.ts
+++ b/src/sofa.ts
@@ -10,14 +10,7 @@ import {
   GraphQLOutputType,
 } from 'graphql';
 
-import {
-  Ignore,
-  Context,
-  ContextFn,
-  ExecuteFn,
-  OnRoute,
-  MethodMap,
-} from './types';
+import { Ignore, ExecuteFn, OnRoute, MethodMap } from './types';
 import { convertName } from './common';
 import { logger } from './logger';
 import { ErrorHandler } from './express';
@@ -31,7 +24,6 @@ import { ErrorHandler } from './express';
 export interface SofaConfig {
   basePath: string;
   schema: GraphQLSchema;
-  context?: Context;
   execute?: ExecuteFn;
   /**
    * Treats an Object with an ID as not a model.
@@ -51,7 +43,6 @@ export interface SofaConfig {
 export interface Sofa {
   basePath: string;
   schema: GraphQLSchema;
-  context: Context;
   models: string[];
   ignore: Ignore;
   depthLimit: number;
@@ -72,9 +63,6 @@ export function createSofa(config: SofaConfig): Sofa {
   logger.debug(`[Sofa] ignore: ${ignore.join(', ')}`);
 
   return {
-    context({ req }) {
-      return { req };
-    },
     execute: graphql,
     models,
     ignore,
@@ -180,8 +168,4 @@ function hasID(type: GraphQLNamedType): type is GraphQLObjectType {
 
 function isNameEqual(a: string, b: string): boolean {
   return convertName(a) === convertName(b);
-}
-
-export function isContextFn(context: any): context is ContextFn {
-  return typeof context === 'function';
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,6 @@
 import { GraphQLArgs, ExecutionResult, DocumentNode } from 'graphql';
 
 export type ContextValue = Record<string, any>;
-export type ContextFn = (init: { req: any; res: any }) => ContextValue;
-export type Context = ContextValue | ContextFn;
 
 export type Ignore = string[];
 


### PR DESCRIPTION
Removed default export and added createSofaRouter decoupled from node
server and any frameworks. Moved context out of main sofa config and moved into middleware specific config.