### PR TITLE
Fix routing with search params

### DIFF
--- a/src/express.ts
+++ b/src/express.ts
@@ -157,7 +157,8 @@ export function createRouter(sofa: Sofa): Router {
     if (!url.startsWith(sofa.basePath)) {
       return null;
     }
-    const slicedUrl = url.slice(sofa.basePath.length);
+    // trim base path and search
+    const [slicedUrl] = url.slice(sofa.basePath.length).split('?');
     const trouterMethod = method.toUpperCase() as Trouter.HTTPMethod;
     const obj = router.find(trouterMethod, slicedUrl);
     for (const handler of obj.handlers) {


### PR DESCRIPTION
I missed trouter expects only path to be provided without search params.
Fixed and added test.