### PR TITLE
[breaking] allow to specify custom path and response status

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const server = http.createServer(async (req, res) => {
       url: req.url,
       body: JSON.parse(await getStream(req)),
       contextValue: {
-        req
+        req,
       },
     });
     if (response) {
@@ -176,17 +176,17 @@ Whenever Sofa tries to resolve an author of a message, instead of exposing an ID
 
 > Pattern is easy: `Type.field` or `Type`
 
-### Customize endpoint's HTTP Method
+### Customize endpoint's HTTP Method, path and response status code
 
-Sofa allows you to cutomize the http method. For example, in case you need `POST` instead of `GET` method in one of your query, you do the following:
+Sofa allows you to cutomize the http method, path and response status. For example, in case you need `POST` instead of `GET` method in one of your query, you do the following:
 
 ```typescript
 api.use(
   '/api',
   sofa({
     schema,
-    method: {
-      'Query.feed': 'POST',
+    routes: {
+      'Query.feed': { method: 'POST' },
     },
   })
 );
@@ -195,6 +195,8 @@ api.use(
 When Sofa tries to define a route for `feed` of `Query`, instead of exposing it under `GET` (default for Query type) it will use `POST` method.
 
 > Pattern is easy: `Type.field` where `Type` is your query or mutation type.
+
+You can also specify `path` with dynamic params support (for example `/feed/:offset/:limit`) and `responseStatus`.
 
 ### Custom depth limit
 

--- a/src/sofa.ts
+++ b/src/sofa.ts
@@ -10,7 +10,7 @@ import {
   GraphQLOutputType,
 } from 'graphql';
 
-import { Ignore, ExecuteFn, OnRoute, MethodMap } from './types';
+import { Ignore, ExecuteFn, OnRoute, Method } from './types';
 import { convertName } from './common';
 import { logger } from './logger';
 import { ErrorHandler } from './express';
@@ -20,6 +20,18 @@ import { ErrorHandler } from './express';
 // - error handler
 // - execute function
 // - context
+
+interface RouteConfig {
+  method?: Method;
+  path?: string;
+  responseStatus?: number;
+}
+
+export interface Route {
+  method: Method;
+  path: string;
+  responseStatus: number;
+}
 
 export interface SofaConfig {
   basePath: string;
@@ -34,10 +46,9 @@ export interface SofaConfig {
   depthLimit?: number;
   errorHandler?: ErrorHandler;
   /**
-   * Overwrites the default HTTP method.
-   * @example {"Query.field": "GET", "Mutation.field": "POST"}
+   * Overwrites the default HTTP route.
    */
-  method?: MethodMap;
+  routes?: Record<string, RouteConfig>;
 }
 
 export interface Sofa {
@@ -46,7 +57,7 @@ export interface Sofa {
   models: string[];
   ignore: Ignore;
   depthLimit: number;
-  method?: MethodMap;
+  routes?: Record<string, RouteConfig>;
   execute: ExecuteFn;
   onRoute?: OnRoute;
   errorHandler?: ErrorHandler;

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,5 +14,3 @@ export interface RouteInfo {
   method: Method;
 }
 export type OnRoute = (info: RouteInfo) => void;
-
-export type MethodMap = Record<string, Method>;


### PR DESCRIPTION
Ref https://github.com/Urigo/SOFA/issues/611 https://github.com/Urigo/SOFA/issues/608 https://github.com/Urigo/SOFA/issues/576

In this diff I replaced `method` map with `routes` map which allows to override default method, path and response status.
Please check if this can solve your problems.

cc @LRipi @basselalaraaj