### PR TITLE
fix(open-api): Added configs for root document object

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -24,6 +24,12 @@ const schema = makeExecutableSchema({
 
 const openApi = OpenAPI({
   schema,
+  servers: [
+    {
+      url: '/', // Specify Server's URL.
+      description: 'Development server',
+    },
+  ],
   info: {
     title: 'Example API',
     version: '3.0.0',

--- a/example/swagger.json
+++ b/example/swagger.json
@@ -4,6 +4,12 @@
     "title": "Example API",
     "version": "3.0.0"
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "Development server"
+    }
+  ],
   "paths": {
     "/me": {
       "get": {

--- a/example/swagger.yml
+++ b/example/swagger.yml
@@ -2,6 +2,9 @@ openapi: 3.0.0
 info:
   title: Example API
   version: 3.0.0
+servers:
+  - url: /
+    description: Development server
 paths:
   /me:
     get:

--- a/src/open-api/index.ts
+++ b/src/open-api/index.ts
@@ -15,18 +15,24 @@ import { OpenAPI } from './interfaces';
 export function OpenAPI({
   schema,
   info,
+  servers,
   components,
   security,
+  tags,
 }: {
   schema: GraphQLSchema;
   info: Record<string, any>;
+  servers?: Record<string, any>[];
   components?: Record<string, any>;
   security?: Record<string, any>[];
+  tags?: Record<string, any>[];
 }) {
   const types = schema.getTypeMap();
   const swagger: any = {
     openapi: '3.0.0',
     info,
+    servers,
+    tags,
     paths: {},
     components: {
       schemas: {},


### PR DESCRIPTION
Added missing fixed field configs for the root document object. Referred: https://swagger.io/specification/

Added configs:
1. servers
2. tags

Updated example as well to showcase how configs will be presented in swagger-ui or swagger.yml / swagger.json