### PR TITLE
docs: add basePath to swagger recipe

### DIFF
--- a/docs/recipes/open-api.md
+++ b/docs/recipes/open-api.md
@@ -19,6 +19,7 @@ app.use(
   '/api',
   useSofa({
     schema,
+    basePath: '/api',
     onRoute(info) {
       openApi.addRoute(info, {
         basePath: '/api',


### PR DESCRIPTION
Without `basePath` it yields the following ts error:

<img width="526" alt="Screenshot 2022-02-13 at 22 35 28" src="https://user-images.githubusercontent.com/1392454/153776077-307c2baa-46ce-410c-a577-f63a149a761d.png">
