### PR TITLE
Fix payload parsing for subscriptions

### DIFF
--- a/src/subscriptions.ts
+++ b/src/subscriptions.ts
@@ -84,17 +84,13 @@ export class SubscriptionManager {
       throw new Error(`Subscription '${name}' is not available`);
     }
 
-    const { document, operationName } = this.operations.get(name)!;
-
     logger.info(`[Subscription] Start ${id}`, event);
 
     const result = await this.execute({
       id,
       name,
       url: event.url,
-      document,
-      operationName,
-      variables: event.variables,
+      boundVariables: event.variables,
       contextValue,
     });
 
@@ -151,25 +147,22 @@ export class SubscriptionManager {
 
   private async execute({
     id,
-    document,
     name,
     url,
-    operationName,
-    variables,
+    boundVariables,
     contextValue,
   }: {
     id: ID;
     name: SubscriptionFieldName;
     url: string;
-    document: DocumentNode;
-    operationName: string;
-    variables: Record<string, any>;
+    boundVariables: Record<string, any>;
     contextValue: ContextValue;
   }) {
-    const variableNodes = this.operations.get(name)!.variables;
-    const variableValues = variableNodes.reduce((values, variable) => {
+    const { document, operationName, variables } = this.operations.get(name)!;
+
+    const variableValues = variables.reduce((values, variable) => {
       const value = parseVariable({
-        value: variables[variable.variable.name.value],
+        value: boundVariables[variable.variable.name.value],
         variable,
         schema: this.sofa.schema,
       });

--- a/src/subscriptions.ts
+++ b/src/subscriptions.ts
@@ -90,7 +90,7 @@ export class SubscriptionManager {
       id,
       name,
       url: event.url,
-      boundVariables: event.variables,
+      variables: event.variables,
       contextValue,
     });
 
@@ -149,20 +149,20 @@ export class SubscriptionManager {
     id,
     name,
     url,
-    boundVariables,
+    variables,
     contextValue,
   }: {
     id: ID;
     name: SubscriptionFieldName;
     url: string;
-    boundVariables: Record<string, any>;
+    variables: Record<string, any>;
     contextValue: ContextValue;
   }) {
-    const { document, operationName, variables } = this.operations.get(name)!;
+    const { document, operationName, variables: variableNodes } = this.operations.get(name)!;
 
-    const variableValues = variables.reduce((values, variable) => {
+    const variableValues = variableNodes.reduce((values, variable) => {
       const value = parseVariable({
-        value: boundVariables[variable.variable.name.value],
+        value: variables[variable.variable.name.value],
         variable,
         schema: this.sofa.schema,
       });

--- a/src/subscriptions.ts
+++ b/src/subscriptions.ts
@@ -84,7 +84,7 @@ export class SubscriptionManager {
       throw new Error(`Subscription '${name}' is not available`);
     }
 
-    const { document, operationName, variables } = this.operations.get(name)!;
+    const { document, operationName } = this.operations.get(name)!;
 
     logger.info(`[Subscription] Start ${id}`, event);
 
@@ -94,7 +94,7 @@ export class SubscriptionManager {
       url: event.url,
       document,
       operationName,
-      variables,
+      variables: event.variables,
       contextValue,
     });
 
@@ -180,7 +180,7 @@ export class SubscriptionManager {
 
       return {
         ...values,
-        [name]: value,
+        [variable.variable.name.value]: value,
       };
     }, {});
 

--- a/tests/subscriptions.spec.ts
+++ b/tests/subscriptions.spec.ts
@@ -142,8 +142,8 @@ test('should start subscriptions with parameters', async () => {
       resolvers: {
         Subscription: {
           onBookBy: {
-            subscribe: withFilter(() => pubsub.asyncIterator(BOOK_ADDED), (payload, variables) => {
-              return payload.onBookBy.author === variables.author;
+            subscribe: withFilter(() => pubsub.asyncIterator(BOOK_ADDED), ( { onBookBy: { author: publishedBy } }, { author: targetAuthor }) => {
+              return publishedBy === targetAuthor;
             }),
           },
         },

--- a/tests/subscriptions.spec.ts
+++ b/tests/subscriptions.spec.ts
@@ -6,7 +6,7 @@ jest.mock('cross-undici-fetch', () => ({
 
 import { fetch } from 'cross-undici-fetch';
 import { makeExecutableSchema } from '@graphql-tools/schema';
-import { PubSub } from 'graphql-subscriptions';
+import { PubSub, withFilter } from 'graphql-subscriptions';
 import supertest from 'supertest';
 import express from 'express';
 import bodyParser from 'body-parser';
@@ -21,19 +21,23 @@ const delay = (ms: number) => {
 const testBook1 = {
   id: 'book-id-1',
   title: 'Test Book 1',
+  author: 'Test Author 1',
 };
 const testBook2 = {
   id: 'book-id-2',
   title: 'Test Book 2',
+  author: 'Test Author 2',
 };
 const BOOK_ADDED = 'BOOK_ADDED';
 const typeDefs = /* GraphQL */ `
   type Book {
     id: ID!
     title: String!
+    author: String!
   }
   type Subscription {
-    onBook: Book!
+    onBook: Book!,
+    onBookBy(author: String!): Book!
   }
   type Query {
     books: [Book!]
@@ -75,7 +79,7 @@ test('should start subscriptions', async () => {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      data: { onBook: { id: 'book-id-1', title: 'Test Book 1' } },
+      data: { onBook: { id: 'book-id-1', title: 'Test Book 1', author: 'Test Author 1' } },
     }),
   });
   pubsub.publish(BOOK_ADDED, { onBook: testBook2 });
@@ -88,7 +92,7 @@ test('should start subscriptions', async () => {
     },
     body: JSON.stringify({ 
       data: {
-        onBook: { id: 'book-id-2', title: 'Test Book 2' } 
+        onBook: { id: 'book-id-2', title: 'Test Book 2', author: 'Test Author 2' } 
       }
     }),
   });
@@ -124,6 +128,51 @@ test('should stop subscriptions', async () => {
   expect(fetch).toBeCalledTimes(1);
   await supertest(app).delete(`/api/webhook/${res.body.id}`).expect(200);
   pubsub.publish(BOOK_ADDED, { onBook: testBook2 });
+  await delay(1000);
+  expect(fetch).toBeCalledTimes(1);
+});
+
+test('should start subscriptions with parameters', async () => {
+  (fetch as jest.Mock).mockClear();
+  const pubsub = new PubSub();
+  const sofa = useSofa({
+    basePath: '/api',
+    schema: makeExecutableSchema({
+      typeDefs,
+      resolvers: {
+        Subscription: {
+          onBookBy: {
+            subscribe: withFilter(() => pubsub.asyncIterator(BOOK_ADDED), (payload, variables) => {
+              return payload.onBookBy.author === variables.author;
+            }),
+          },
+        },
+      },
+    }),
+  });
+
+  const app = express();
+  app.use(bodyParser.json());
+  app.use('/api', sofa);
+
+  const res = await supertest(app)
+    .post('/api/webhook')
+    .send({ subscription: 'onBookBy', url: '/bookBy', variables: { author: 'Test Author 1' } })
+    .expect(200);
+  expect(res.body).toEqual({ id: expect.any(String) });
+  pubsub.publish(BOOK_ADDED, { onBookBy: testBook1 });
+  await delay(1000);
+  expect(fetch).toBeCalledTimes(1);
+  expect(fetch).toBeCalledWith('/bookBy', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      data: { onBookBy: { id: 'book-id-1', title: 'Test Book 1', author: 'Test Author 1' } },
+    }),
+  });
+  pubsub.publish(BOOK_ADDED, { onBookBy: testBook2 });
   await delay(1000);
   expect(fetch).toBeCalledTimes(1);
 });


### PR DESCRIPTION
Currently the subscription manager do not parse in a proper way the JSON payload for parametrical subscriptions.

The PR fixes this behaviour, applying in the existing reduction the event variables to the subscription schema and using for each variable the designated name from the schema