### PR TITLE
Stop using AST Node to retrieve Enum values in OpenAPI

### DIFF
--- a/src/open-api/types.ts
+++ b/src/open-api/types.ts
@@ -79,7 +79,7 @@ export function resolveFieldType(
   if (isEnumType(type)) {
     return {
       type: 'string',
-      enum: type.astNode?.values?.map((value) => value.name.value),
+      enum: type.getValues().map((value) => value.name),
     };
   }
 


### PR DESCRIPTION
`GraphQLEnumType` may not have `astNode`, for example, NestJS.
It is better to use `getValues()` instead of `astNode`, because you can always get enum values.