### PR TITLE
Allow to override mapping of custom scalar to OpenAPI

### DIFF
--- a/src/open-api/index.ts
+++ b/src/open-api/index.ts
@@ -19,6 +19,7 @@ export function OpenAPI({
   components,
   security,
   tags,
+  customScalars = {},
 }: {
   schema: GraphQLSchema;
   info: Record<string, any>;
@@ -26,6 +27,16 @@ export function OpenAPI({
   components?: Record<string, any>;
   security?: Record<string, any>[];
   tags?: Record<string, any>[];
+  /**
+   * Override mapping of custom scalars to OpenAPI
+   * @example
+   * ```js
+   * {
+   *   Date: { type: "string",  format: "date" }
+   * }
+   * ```
+   */
+  customScalars?: Record<string, any>;
 }) {
   const types = schema.getTypeMap();
   const swagger: any = {
@@ -46,7 +57,9 @@ export function OpenAPI({
       (isObjectType(type) || isInputObjectType(type)) &&
       !isIntrospectionType(type)
     ) {
-      swagger.components!.schemas![typeName] = buildSchemaObjectFromType(type);
+      swagger.components!.schemas![typeName] = buildSchemaObjectFromType(type, {
+        customScalars,
+      });
     }
   }
 
@@ -82,6 +95,7 @@ export function OpenAPI({
         operation: info.document,
         schema,
         useRequestBody: ['POST', 'PUT', 'PATCH'].includes(info.method),
+        customScalars,
       });
     },
     get() {

--- a/src/open-api/operations.ts
+++ b/src/open-api/operations.ts
@@ -21,11 +21,13 @@ export function buildPathFromOperation({
   schema,
   operation,
   useRequestBody,
+  customScalars,
 }: {
   url: string;
   schema: GraphQLSchema;
   operation: DocumentNode;
   useRequestBody: boolean;
+  customScalars: Record<string, any>;
 }): any {
   const info = getOperationInfo(operation)!;
 
@@ -57,6 +59,7 @@ export function buildPathFromOperation({
             schema: resolveResponse({
               schema,
               operation: info.operation,
+              customScalars,
             }),
           },
         },
@@ -137,9 +140,11 @@ function resolveParamSchema(type: TypeNode): any {
 function resolveResponse({
   schema,
   operation,
+  customScalars,
 }: {
   schema: GraphQLSchema;
   operation: OperationDefinitionNode;
+  customScalars: Record<string, any>;
 }) {
   const operationType = operation.operation;
   const rootField = operation.selectionSet.selections[0];
@@ -149,14 +154,14 @@ function resolveResponse({
       const queryType = schema.getQueryType()!;
       const field = queryType.getFields()[rootField.name.value];
 
-      return resolveFieldType(field.type);
+      return resolveFieldType(field.type, { customScalars });
     }
 
     if (operationType === 'mutation') {
       const mutationType = schema.getMutationType()!;
       const field = mutationType.getFields()[rootField.name.value];
 
-      return resolveFieldType(field.type);
+      return resolveFieldType(field.type, { customScalars });
     }
   }
 }

--- a/tests/open-api/operations.spec.ts
+++ b/tests/open-api/operations.spec.ts
@@ -43,6 +43,7 @@ test('handle query', async () => {
     },
     schema,
     useRequestBody: false,
+    customScalars: {},
   });
 
   expect(result.operationId).toEqual('feed_query');
@@ -82,6 +83,7 @@ test('handle mutation', async () => {
     },
     schema,
     useRequestBody: true,
+    customScalars: {},
   });
 
   // id

--- a/tests/open-api/types.spec.ts
+++ b/tests/open-api/types.spec.ts
@@ -34,6 +34,7 @@ test('handle ObjectType', async () => {
       name: String!
       age: Int!
       profile: Profile
+      birthday: Date!
     }
 
     input UserInput {
@@ -41,6 +42,8 @@ test('handle ObjectType', async () => {
       age: Int!
       profile: Profile
     }
+
+    scalar Date
   `);
 
   const userType = schema.getType('User') as GraphQLObjectType;
@@ -48,14 +51,15 @@ test('handle ObjectType', async () => {
   const addressType = schema.getType('Address') as GraphQLObjectType;
   const userInputType = schema.getType('UserInput') as GraphQLInputObjectType;
 
-  const user = buildSchemaObjectFromType(userType);
-  const profile = buildSchemaObjectFromType(profileType);
-  const address = buildSchemaObjectFromType(addressType);
-  const userInput = buildSchemaObjectFromType(userInputType);
+  const customScalars = { Date: { type: 'string', format: 'date' } };
+  const user = buildSchemaObjectFromType(userType, { customScalars });
+  const profile = buildSchemaObjectFromType(profileType, { customScalars });
+  const address = buildSchemaObjectFromType(addressType, { customScalars });
+  const userInput = buildSchemaObjectFromType(userInputType, { customScalars });
 
   expect(user).toEqual({
     type: 'object',
-    required: ['role', 'name', 'age'],
+    required: ['role', 'name', 'age', 'birthday'],
     properties: {
       role: {
         enum: ['ADMIN', 'NORMAL'],
@@ -67,6 +71,10 @@ test('handle ObjectType', async () => {
       age: {
         type: 'integer',
         format: 'int32',
+      },
+      birthday: {
+        type: 'string',
+        format: 'date',
       },
       profile: {
         $ref: '#/components/schemas/Profile',


### PR DESCRIPTION
In the current implementation, all custom scalars are mapped to `{ type: "object" }` on OpenAPI. However, `object` is not appropriate because, for example, a `Date` scalar is a string of the form `"YYYYY-mm-dd"`.
This PR implements the `customScalars` option to control the type of custom scalars when mapping them to OpenAPI.