### PR TITLE
Pass GraphQL field description to OpenAPI schema

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -101,14 +101,14 @@ export function createRouter(sofa: Sofa) {
         const sofaServerContext = {
           ...serverContext,
           request,
-        }
+        };
         const contextValue = await sofa.contextFactory(sofaServerContext);
         const result = await subscriptionManager.update(
           {
             id,
             variables,
           },
-          contextValue,
+          contextValue
         );
         return new Response(JSON.stringify(result), {
           status: 200,
@@ -202,7 +202,7 @@ function createQueryRoute({
     path: route.path,
     method: route.method.toUpperCase() as Method,
     tags: routeConfig?.tags ?? [],
-    description: routeConfig?.description ?? '',
+    description: routeConfig?.description ?? field.description ?? '',
   };
 }
 
@@ -218,6 +218,7 @@ function createMutationRoute({
   logger.debug(`[Router] Creating ${fieldName} mutation`);
 
   const mutationType = sofa.schema.getMutationType()!;
+  const field = mutationType.getFields()[fieldName];
   const operationNode = buildOperationNodeForField({
     kind: 'mutation' as OperationTypeNode,
     schema: sofa.schema,
@@ -250,7 +251,7 @@ function createMutationRoute({
     path,
     method,
     tags: routeConfig?.tags || [],
-    description: routeConfig?.description || '',
+    description: routeConfig?.description ?? field.description ?? '',
   };
 }
 

--- a/tests/router.spec.ts
+++ b/tests/router.spec.ts
@@ -372,3 +372,69 @@ test('should override error response with errorHandler', async () => {
   const resBody = await res.json();
   expect(resBody).toEqual({ message: 'permission denied' });
 });
+
+it('should pass field descriptions to onRoute', () => {
+  const spy = jest.fn();
+  useSofa({
+    basePath: '/api',
+    schema: createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          """
+          this is query
+          """
+          foo: String
+        }
+        type Mutation {
+          """
+          this is mutation
+          """
+          bar(arg1: Int): String
+        }
+      `,
+    }),
+    onRoute: spy,
+  });
+
+  expect(spy).toBeCalledTimes(2);
+  expect(spy.mock.calls[0][0].description).toEqual('this is query');
+  expect(spy.mock.calls[1][0].description).toEqual('this is mutation');
+});
+
+test('should overwrite field descriptions', () => {
+  const spy = jest.fn();
+  useSofa({
+    basePath: '/api',
+    schema: createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          """
+          this is query
+          """
+          foo: String
+        }
+        type Mutation {
+          """
+          this is mutation
+          """
+          bar(arg1: Int): String
+        }
+      `,
+    }),
+    onRoute: spy,
+    routes: {
+      'Query.foo': { description: 'this is overwrited query description' },
+      'Mutation.bar': {
+        description: 'this is overwrited mutation description',
+      },
+    },
+  });
+
+  expect(spy).toBeCalledTimes(2);
+  expect(spy.mock.calls[0][0].description).toEqual(
+    'this is overwrited query description'
+  );
+  expect(spy.mock.calls[1][0].description).toEqual(
+    'this is overwrited mutation description'
+  );
+});


### PR DESCRIPTION
Comments on GraphQL fields were not reflected in the OpenAPI schema