### PR TITLE
Support true boolean

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -45,8 +45,7 @@ function resolveVariable({
     if (isScalarType(namedType)) {
       // GraphQLBoolean.serialize expects a boolean or a number only
       if (isEqualType(GraphQLBoolean, namedType)) {
-        // we don't support TRUE
-        value = value === 'true';
+        value = (value === 'true' || value === true);
       }
 
       return namedType.serialize(value);


### PR DESCRIPTION
It seems that the library does not support boolean types as a REST input. Which seems like an artificial limitation. 

this PR intends to fix that.