### PR TITLE
fix: prevent overwriting descriptions of field with custom scalar

### DIFF
--- a/src/open-api/types.ts
+++ b/src/open-api/types.ts
@@ -74,14 +74,12 @@ export function resolveFieldType(
   }
 
   if (isScalarType(type)) {
-    return (
-      mapToPrimitive(type.name) ||
-      opts.customScalars[type.name] || 
-      type.extensions?.jsonSchema
-      || {
+    const resolved = mapToPrimitive(type.name) ||
+      opts.customScalars[type.name] ||
+      type.extensions?.jsonSchema || {
         type: 'object',
-      }
-    );
+      };
+    return { ...resolved };
   }
 
   if (isEnumType(type)) {

--- a/tests/open-api/types.spec.ts
+++ b/tests/open-api/types.spec.ts
@@ -39,7 +39,14 @@ test('handle ObjectType', async () => {
       name: String!
       age: PositiveInt!
       profile: Profile
+      """
+      User's birthday
+      """
       birthday: Date!
+      """
+      User's registration date
+      """
+      registrationDate: Date!
     }
 
     input UserInput {
@@ -71,7 +78,7 @@ test('handle ObjectType', async () => {
 
   expect(user).toEqual({
     type: 'object',
-    required: ['role', 'name', 'age', 'birthday'],
+    required: ['role', 'name', 'age', 'birthday', 'registrationDate'],
     properties: {
       role: {
         enum: ['ADMIN', 'NORMAL'],
@@ -88,6 +95,12 @@ test('handle ObjectType', async () => {
       birthday: {
         type: 'string',
         format: 'date',
+        description: "User's birthday",
+      },
+      registrationDate: {
+        type: 'string',
+        format: 'date',
+        description: "User's registration date",
       },
       profile: {
         $ref: '#/components/schemas/Profile',


### PR DESCRIPTION
In the current implementation, when two or more custom scalars are used, the `description` of the field is overwritten with that of the last field defined.

e.g. GraphQL schema

```graphql
scalar Date

type User {
  """
  User's birthday
  """
  birthday: Date

  """
  User's registration date
  """
  registrationDate: Date
}
```

generated OpenAPI schema

```jsonc
{
  "properties": {
    "birthday": {
      "type": "string"
      "format": "date",
      "description": "User's birthday" // <= expect "User's registration date"
    },
    "registrationDate": {
      "type": "string"
      "format": "date",
      "description": "User's registration date"
    }
  }
}
```