### PR TITLE
Support HTTP query parameters in POST, PUT, PATCH routes + solve models mis-calculation when multiple queries return the same singular/plural objects

### DIFF
--- a/src/open-api/operations.ts
+++ b/src/open-api/operations.ts
@@ -40,6 +40,13 @@ export function buildPathFromOperation({
   const enumTypes = resolveEnumTypes(schema);
 
   const summary = resolveDescription(schema, info.operation);
+  const variables = info.operation.variableDefinitions;
+  const pathParams = variables?.filter((variable: any) =>
+    isInPath(url, variable.variable.name.value)
+  );
+  const bodyParams = variables?.filter(
+    (variable: any) => !isInPath(url, variable.variable.name.value)
+  );
 
   return {
     tags,
@@ -48,11 +55,18 @@ export function buildPathFromOperation({
     operationId: info.name,
     ...(useRequestBody
       ? {
+          parameters: resolveParameters(
+            url,
+            pathParams,
+            schema,
+            info.operation,
+            { customScalars, enumTypes }
+          ),
           requestBody: {
             content: {
               'application/json': {
                 schema: resolveRequestBody(
-                  info.operation.variableDefinitions,
+                  bodyParams,
                   schema,
                   info.operation,
                   { customScalars, enumTypes }
@@ -64,7 +78,7 @@ export function buildPathFromOperation({
       : {
           parameters: resolveParameters(
             url,
-            info.operation.variableDefinitions,
+            variables,
             schema,
             info.operation,
             { customScalars, enumTypes }

--- a/src/sofa.ts
+++ b/src/sofa.ts
@@ -140,7 +140,7 @@ function extractsModels(schema: GraphQLSchema): string[] {
           isNonNullType(arg.type)
         );
 
-        modelMap[namedType.name].list = sameName && allOptionalArguments;
+        modelMap[namedType.name].list ||= sameName && allOptionalArguments;
       } else if (
         isObjectType(field.type) ||
         (isNonNullType(field.type) && isObjectType(field.type.ofType))
@@ -153,7 +153,7 @@ function extractsModels(schema: GraphQLSchema): string[] {
         const hasIdArgument =
           field.args.length === 1 && field.args[0].name === 'id';
 
-        modelMap[namedType.name].single = sameName && hasIdArgument;
+        modelMap[namedType.name].single ||= sameName && hasIdArgument;
       }
     }
   }


### PR DESCRIPTION
* Fixes https://github.com/Urigo/SOFA/issues/1255
* Fixes https://github.com/Urigo/SOFA/issues/1259