### PR TITLE
Export createRouter and createSofa methods

### DIFF
--- a/.changeset/mighty-mugs-remain.md
+++ b/.changeset/mighty-mugs-remain.md
@@ -1,0 +1,5 @@
+---
+"sofa-api": patch
+---
+
+Export `createSofa` and `createRoute` for custom intermediate configuration

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { createSofa } from './sofa';
 export { OpenAPI } from './open-api';
 
 export function useSofa(config: SofaConfig) {
-  return createRouter(
-    createSofa(config)
-  );
+  return createRouter(createSofa(config));
 }
+
+export { createRouter, createSofa };


### PR DESCRIPTION
## Preamble

Currently, SOFA evaluates whether a type is a model or not by looking for both a single endpoint with a non-optional id and a list endpoint that returns a raw list of the type.

However, some more mature schemas will reasonably change the way objects are accessed to include pagination or even intermediate [nodes ala Github](https://docs.github.com/en/graphql/guides/introduction-to-graphql#connection). For example:

```gql
type Chat {
  id: ID
  text: String
}

type ChatList {
  results: [Chat]
  cursor: String
}

type Query {
  chat(id: ID): Chat
  chats: ChatList
  me: Chat
  recentChats: ChatList
}
```

While it'd ideal for SOFA to understand this kind of special syntax for identifying models, it turns out to be easier for bigger codebases to manually pass the `models` argument into `createRouter`. This is not currently possible with the current exports defined by the library.

## Description

This PR allows for anyone to replace `useSofa` with the use of `createRouter` and `createSofa`, so that custom configuration can be hooked in.